### PR TITLE
Chore/php8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-versions: ['7.4','8.1','8.2']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer --no-interaction install
+      - name: PHPUnit tests
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 .DS_Store
+/vendor
+/composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 /vendor
 /composer.lock
+/.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Support for PHP 8.1 and up
+- Unit tests run in CI
+
+## [Earlier Releases]
+
+Releases up to and including v1.0.0 predate this changelog.

--- a/README.markdown
+++ b/README.markdown
@@ -2,6 +2,8 @@
 
 OptionParser is a parser for command-line options for PHP. It supports both short and long options, optional and/or required parameter checking, automatic callback execution, and pretty printing of usage messages.
 
+This package is a dependency of Whippet. It's been forked by dxw because the upstream repo is no longer maintained.
+
 ### Usage
 
 First create a parser object and then use it to parse your arguments. Examples explain it best:
@@ -62,7 +64,7 @@ A Unix-style executable is also provided for *nix users:
 
 OptionParser uses the [PHPUnit](http://www.phpunit.de/) unit testing framework to test the code. In order to run the tests, run the following command from the project root directory:
 
-    $ phpunit tests/OptionParser.php
+    $ vendor/bin/phpunit
 
 ### Credits
 

--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
     "type": "library",
     "autoload": {
         "files": ["lib/OptionParser.php"]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit>
+	<testsuites>
+		<testsuite name="unit">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/OptionParserTest.php
+++ b/tests/OptionParserTest.php
@@ -1,17 +1,15 @@
 <?php
 
-require_once 'PHPUnit/Framework.php';
-
 require_once dirname(dirname(__FILE__)) . '/lib/OptionParser.php';
 
-class OptionParserTest extends PHPUnit_Framework_TestCase
+class OptionParserTest extends PHPUnit\Framework\TestCase
 {
 
     public function testInvalidOption()
     {
         $op = new OptionParser;
 
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
 
         $args = array('-', '-c');
         $op->parse($args);
@@ -101,7 +99,7 @@ class OptionParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($op->b, 1);
         $this->assertEquals($op->c, 'string');
 
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
 
         $args = array('-', '-c');
         $op->parse($args);
@@ -136,7 +134,7 @@ class OptionParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($op->getOption('long-req'), 'hi there');
         $this->assertEquals($op->getOption('long-opt'), '-a');
 
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
 
         $args = array('-', '--dir-name');
         $op->parse($args);


### PR DESCRIPTION
This PR:

- Updates the repo's dependencies so PHPUnit is required as a dev dependency, rather than required to be installed globally
- Updates the test config and syntax to be PHPUnit 9 compatible
- Slightly updates the README to explain why we maintain this repo
- Runs the unit tests in CI in PHP 7.4, 8.1 & 8.2 so we can verify the package will be PHP8-compatible
- Adds a CHANGELOG